### PR TITLE
Add Malware Security, move Hacktive to amalgamations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,32 +13,33 @@ This list details companies that are considered to be 'amalgamated' having been 
 
 |Company Name|Website|Parent Company / Independent|Main Location|Size|Hiring?|Student Intake?|Notes|
 |---|---|---|---|---|---|---|---|
-|Alcorn Group|No longer exists (Redirects to CyberCx) |[CyberCx](https://www.cybercx.com.au/ "CyberCx")|Brisbane|N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a |
-|Assurance|No longer exists (Redirects to CyberCx)  |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Melbourne   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
-|Asterisk   |No longer exists (Redirects to CyberCx)  |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Perth   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a  |
-|CQR   |No longer exists (Redirects to CyberCx)  |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Adelaide   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
-|Diamond Cyber|No longer exists (Redirects to CyberCx)   |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Perth   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
-|Foresight   |<https://foresight.security/>   | [CyberCx](https://www.cybercx.com.au/ "CyberCx")  |Canberra   |N/a   |[Yes](https://foresight.security/careers)   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
-|Insomnia   |<https://insomniasec.com>   | [CyberCx](https://www.cybercx.com.au/ "CyberCx")  |New Zealand   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
-|Sense of Security   |No longer exists (Redirects to CyberCx)  |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Sydney   | N/a  | N/a  | [Yes](https://cybercx.com.au/graduate/)  | N/a  |
-|Shearwater   |No longer exists (Redirects to CyberCx)   |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Sydney   | N/a  | N/a  | [Yes](https://cybercx.com.au/graduate/) | N/a  |
+| Alcorn Group|No longer exists (Redirects to CyberCx) |[CyberCx](https://www.cybercx.com.au/ "CyberCx")|Brisbane|N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a |
+| Assurance|No longer exists (Redirects to CyberCx)  |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Melbourne   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
+| Asterisk   |No longer exists (Redirects to CyberCx)  |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Perth   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a  |
+| CQR   |No longer exists (Redirects to CyberCx)  |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Adelaide   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
+| Diamond Cyber|No longer exists (Redirects to CyberCx)   |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Perth   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
+| Foresight   |<https://foresight.security/>   | [CyberCx](https://www.cybercx.com.au/ "CyberCx")  |Canberra   |N/a   |[Yes](https://foresight.security/careers)   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
+| Hacktive | <https://hacktive.io/>  |  [Deloitte](https://www.deloitte.com/au/en.html) |  Sydney |  ~8 |  N/a | N/a  |  N/a |
+| Insomnia   |<https://insomniasec.com>   | [CyberCx](https://www.cybercx.com.au/ "CyberCx")  |New Zealand   |N/a   |N/a   |[Yes](https://cybercx.com.au/graduate/)   |N/a   |
+| Sense of Security   |No longer exists (Redirects to CyberCx)  |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Sydney   | N/a  | N/a  | [Yes](https://cybercx.com.au/graduate/)  | N/a  |
+| Shearwater   |No longer exists (Redirects to CyberCx)   |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Sydney   | N/a  | N/a  | [Yes](https://cybercx.com.au/graduate/) | N/a  |
 | TSS Cyber  | No longer exists (Redirects to CyberCx) |[CyberCx](https://www.cybercx.com.au/ "CyberCx")   |Canberra  |N/a   |N/a  | [Yes](https://cybercx.com.au/graduate/) | N/a  |
 | Yell IT  | No longer exists (Redirects to CyberCx) | [CyberCx](https://www.cybercx.com.au/ "CyberCx")  | Brisbane  | ~30  | N/a  | [Yes](https://cybercx.com.au/graduate/)  | N/a  |
 | CXO Security  | <https://www.cxosecurity.com.au>  |  [Sekuro](https://sekuro.io/) |   Sydney|  N/a |  N/a | N/a  |  N/a |
 | Solista  | <https://solista.com.au/>  | [Sekuro](https://sekuro.io/)  | Sydney  | N/a  | N/a  | N/a | N/a  |
 | Privasec  | <https://privasec.com/>  |  [Sekuro](https://sekuro.io/) |  Sydney | ~50  |  [Yes](https://privasec.com/why-us/careers "Jobs") |  [Yes, specific program for grads and interns](https://red.privasec.com/careers/hackcelerator "Hackcelerator") |  N/a |
 | Ernst & Young (EY)  | <https://www.ey.com>  |  Big Four | Global  |  N/a | N/a  | N/a  | N/a|
-|  PWC |  <https://www.pwc.com.au/> |  Big Four  | Global  |  N/a |  N/a |  N/a | N/a  |
+| PWC |  <https://www.pwc.com.au/> |  Big Four  | Global  |  N/a |  N/a |  N/a | N/a  |
 | Deloitte  |  <https://www2.deloitte.com> | Big Four |  Global |  N/a |  N/a | N/a  | N/a  |
-|  KPMG |  <https://home.kpmg> | Big Four  |  Global | N/a  | N/a  |  N/a |  N/a |
+| KPMG |  <https://home.kpmg> | Big Four  |  Global | N/a  | N/a  |  N/a |  N/a |
 | Lateral Security |  <https://www.lateralsecurity.com/> |  [Tesserent](https://tesserent.com "Tesserent") | Sydney  |  N/a | N/a  | N/a  |  N/a |
 | Loop Secure  |  <https://www.loopsec.com.au> |  [Tesserent](https://tesserent.com "Tesserent") | Sydney  |  N/a | [Yes](https://www.loopsec.com.au/about/join-us "Jobs")  | N/a  |  N/a |
-|  Ludus Cyber Security | <https://luduscybersecurity.com/>  | [Tesserent](https://tesserent.com "Tesserent")  | Canberra  | ~8  | N/a  |  N/a |  N/a |
+| Ludus Cyber Security | <https://luduscybersecurity.com/>  | [Tesserent](https://tesserent.com "Tesserent")  | Canberra  | ~8  | N/a  |  N/a |  N/a |
 | North  | <https://northsd.com.au/>  | [Tesserent](https://tesserent.com "Tesserent")  |  Canberra |  N/a | Yes  | N/a  |  N/a |
 | Pure Security  | <https://pure.security/>  | [Tesserent](https://tesserent.com "Tesserent")  |  Melbourne |  ~40 | Yes  | N/a  |  Amalgamation of PureHacking,  HackLabs, SecurusGlobal, and Certitude  |
 | Seer Security  | <https://www.seersec.com.au/> |  [Tesserent](https://tesserent.com "Tesserent") |  Canberra | ~10  |  N/a | N/a  | N/a  |
-|  Context IS | <https://www.contextis.com>  |  [Accenture](https://www.accenture.com/au-en/services/security-index "Accenture Security") | Global (UK)  |  N/a |  N/a | Yes, hires grads and interns  | N/a  |
-|  Trustwave    | <https://www.trustwave.com/>  |  Singtel |  Global (USA) | N/a  | [Yes](https://jobs.jobvite.com/trustwave "Jobs")  | Yes, hires grads/interns  |  N/a |
+| Context IS | <https://www.contextis.com>  |  [Accenture](https://www.accenture.com/au-en/services/security-index "Accenture Security") | Global (UK)  |  N/a |  N/a | Yes, hires grads and interns  | N/a  |
+| Trustwave    | <https://www.trustwave.com/>  |  Singtel |  Global (USA) | N/a  | [Yes](https://jobs.jobvite.com/trustwave "Jobs")  | Yes, hires grads/interns  |  N/a |
 | eSecure  |  <https://www.esecure.com.au> | [Orro](https://orro.group/)  |  Melbourne | ~35  | [Yes](https://www.esecure.com.au/opportunities "Jobs") | Yes, hires graduates  |  N/a |
 
 
@@ -50,35 +51,35 @@ This list details companies that are considered to be 'independent' with no over
 |---|---|---|---|---|---|---|---|
 | AirGlow Security  | <https://airglowsecurity.com.au>  |  Independent |   Melbourne|  N/a |  N/a | N/a  |  N/a |
 | Aurian Security | <https://www.aurian.com.au> | Independent | Sydney, Brisbane | ~2 | N/a | N/a | N/a |
-|  Content Security |  <https://www.contentsecurity.com.au/> | Independent  | Sydney  |  ~40 |  N/a |  N/a |  N/a |
-|  Cyber Partners |  <https://cyberpartners.com.au/> | Independent  | Brisbane  |  ~5 | N/a  |  N/a | N/a  |
+| Content Security |  <https://www.contentsecurity.com.au/> | Independent  | Sydney  |  ~40 |  N/a |  N/a |  N/a |
+| Cyber Partners |  <https://cyberpartners.com.au/> | Independent  | Brisbane  |  ~5 | N/a  |  N/a | N/a  |
 | Elttam | <https://www.elttam.com/> | Independent | Melbourne | ~20 | N/a | N/a | N/a |
 | Fireeye (Mandiant)  |  <https://www.fireeye.com/mandiant.html> | Independent  |  Global (USA)|  N/a | N/a  | N/a  | N/a  |
 | GridWave  |  <https://www.gridware.com.au> |  Independent |  Sydney   |  ~10 |  N/a | Yes, [Internship program](https://www.gridware.com.au/internships/ "Internships")  |  N/a |
-|  Hacktive | <https://hacktive.io/>  |  Independent |  Sydney |  ~8 |  N/a | N/a  |  N/a |
 | IBM (X-Force Red) | <https://www.ibm.com/au-en/security/services/offensive-security-services> | Independent  |  Global (USA)|  N/a | N/a  | N/a  | N/a  |
-|  InfoTrust | <https://infotrust.com.au/>  | Independent  |  Sydney | ~30  | [Yes](https://infotrust.com.au/careers/ "Jobs")  |  N/a | N/a  |
+| InfoTrust | <https://infotrust.com.au/>  | Independent  |  Sydney | ~30  | [Yes](https://infotrust.com.au/careers/ "Jobs")  |  N/a | N/a  |
 | Intalock  | <https://www.intalock.com.au/>  | Independent  |  Brisbane |  ~20 | N/a  |  N/a |  N/a |
 | Ionize  | <https://ionize.com.au>  | Independent  |  Sydney |  ~20 |   [Yes](https://ionize.com.au/careers/ "Jobs")| N/a  |  N/a |
-|  Mercury Infosec |  <https://mercuryiss.com.au> | Independent  | Sydney  |  ~10 | Yes | N/a  |  N/a |
-|  NCC Group| <https://www.nccgroup.com>  |  Independent |  Global (UK)  | N/a | [Yes](https://www.nccgroupplc.com/careers/ "Jobs")  |  Yes, hires grads and interns |  N/a |
-|  Pulse Security   |  <https://pulsesecurity.co.nz/> |  Independent | New Zealand  |  N/a |  N/a |  N/a | N/a  |
-|  Quantum Security Services   |  <https://www.quantumsecurity.co.nz/> |  Independent | New Zealand  |  N/a |  N/a |  N/a | N/a  |
-|  RedCursor |  <https://www.redcursor.com.au/> |  Independent | Sydney  | ~4  |  N/a |  Yes, hires grads/interns |  N/a |
-|  Rightsec |  <https://www.rightsec.com.au> |  Independent | Brisbane  |  ~3 | N/a  |  N/a |  N/a |
+| Malware Security | <https://malsec.com.au> | Independent | Canberra | ~15 | Yes | N/a | N/a |
+| Mercury Infosec |  <https://mercuryiss.com.au> | Independent  | Sydney  |  ~10 | Yes | N/a  |  N/a |
+| NCC Group| <https://www.nccgroup.com>  |  Independent |  Global (UK)  | N/a | [Yes](https://www.nccgroupplc.com/careers/ "Jobs")  |  Yes, hires grads and interns |  N/a |
+| Pulse Security   |  <https://pulsesecurity.co.nz/> |  Independent | New Zealand  |  N/a |  N/a |  N/a | N/a  |
+| Quantum Security Services   |  <https://www.quantumsecurity.co.nz/> |  Independent | New Zealand  |  N/a |  N/a |  N/a | N/a  |
+| RedCursor |  <https://www.redcursor.com.au/> |  Independent | Sydney  | ~4  |  N/a |  Yes, hires grads/interns |  N/a |
+| Rightsec |  <https://www.rightsec.com.au> |  Independent | Brisbane  |  ~3 | N/a  |  N/a |  N/a |
 | Secolve |  <https://www.secolve.com/> |  Independent | Sydney  |  ~2 |  N/a |  N/a |  N/a |
 | Security Centric  |  <https://www.securitycentric.com.au/> |  Independent | Sydney  |  ~8 |  N/a |  N/a |  N/a |
 | Sentaris  |  <https://www.sentaris.com.au/> |  Independent | Melbourne  | ~6  | N/a  | N/a  |  N/a |
 | Shea  Security |  <https://sheasecurity.com.au/> |  Independent |  Melbourne |  ~3 |  N/a |  N/a | N/a  |
-|  Silent Grid |  <https://www.silentgrid.com/> | Independent  | Sydney  | N/a | N/a  |  N/a |  N/a |
-|  Skylight Cyber |  <https://skylightcyber.com/> | Independent  | Sydney  | N/a | N/a  |  N/a |  N/a |
-|  StickmanCyber | <https://www.stickmancyber.com>  | Independent  |  Sydney |  ~30 | [Yes](https://www.stickmancyber.com/careers)  | Yes, Hires Grad/Interns|  N/a |
-|  Themissinglink (TML) |  <https://www.themissinglink.com.au> |  Independent |  Sydney |  ~100 |  [Yes](https://www.themissinglink.com.au/careers "Jobs") | N/a  |  N/a |
-|  Triskele Labs   |  <https://triskelelabs.com/> |  Independent | Melbourne  |  ~20 |  N/a |  [Yes](https://triskelelabs.com/careers-overview/) | N/a  |
+| Silent Grid |  <https://www.silentgrid.com/> | Independent  | Sydney  | N/a | N/a  |  N/a |  N/a |
+| Skylight Cyber |  <https://skylightcyber.com/> | Independent  | Sydney  | N/a | N/a  |  N/a |  N/a |
+| StickmanCyber | <https://www.stickmancyber.com>  | Independent  |  Sydney |  ~30 | [Yes](https://www.stickmancyber.com/careers)  | Yes, Hires Grad/Interns|  N/a |
+| Themissinglink (TML) |  <https://www.themissinglink.com.au> |  Independent |  Sydney |  ~100 |  [Yes](https://www.themissinglink.com.au/careers "Jobs") | N/a  |  N/a |
+| Triskele Labs   |  <https://triskelelabs.com/> |  Independent | Melbourne  |  ~20 |  N/a |  [Yes](https://triskelelabs.com/careers-overview/) | N/a  |
 | Threat Intelligence  |  <https://www.threatintelligence.com> | Independent  |  Sydney |  ~10 |  [Yes](https://www.threatintelligence.com "Jobs") | No  |  N/a |
-|  Vertex Security   |  <https://www.vtxsecurity.com.au/> |  Independent | Sydney |  ~5 |  N/a |  N/a | N/a |
-|  Volkis   |  <https://www.volkis.com.au/> |  Independent | Sydney, Brisbane |  ~3 |  N/a |  W.I.P | 🐺 |
-|  Zerosource   |  <https://www.zerosource.io/> |  Independent | Sydney, Canberra |  ~5 |  N/a |  N/a | N/a |
-|  ZX Security Ltd   |  <https://zxsecurity.co.nz/> |  Independent | New Zealand  |  ~20 |  N/a |  [Summer of Tech](https://summeroftech.co.nz/) | N/a  |
+| Vertex Security   |  <https://www.vtxsecurity.com.au/> |  Independent | Sydney |  ~5 |  N/a |  N/a | N/a |
+| Volkis   |  <https://www.volkis.com.au/> |  Independent | Sydney, Brisbane |  ~3 |  N/a |  W.I.P | 🐺 |
+| Zerosource   |  <https://www.zerosource.io/> |  Independent | Sydney, Canberra |  ~5 |  N/a |  N/a | N/a |
+| ZX Security Ltd   |  <https://zxsecurity.co.nz/> |  Independent | New Zealand  |  ~20 |  N/a |  [Summer of Tech](https://summeroftech.co.nz/) | N/a  |
 
 


### PR DESCRIPTION
PR to add Malware Security to the list please.  Also moved Hacktive to amalgamations as purchased by Deloitte in 2020 - https://www.deloitte.com/au/en/about/press-room/team-from-leading-cyber-security-managed-services-consultancy-hacktive-join-deloitte-041022.html